### PR TITLE
Wheel-Workflow: ignore useless files

### DIFF
--- a/.github/workflows/build-and-publish-wheels.yml
+++ b/.github/workflows/build-and-publish-wheels.yml
@@ -4,6 +4,15 @@ name: Build Wheels
 on:
   push:
     branches: [ master, dev ]
+    paths-ignore:
+      - '.gitignore'
+      - '.npmignore'
+      - '.pre-commit-config.yaml'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'README.md'
+      - '.github/*'
+      - 'example/*'
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ From YouTube Live stream to Video
 > - 360p = 640
 > - 480p = 864
 > - 720p = 1280
-> 
+>
 > If you have any problem with green screen or un-synchronized video, it can be one of the problem:
 > - Invalid FFMPEG command
 > - The video quality is higher than the original video


### PR DESCRIPTION
Avoid an useless run of the Workflow when pushing to wheel-unrelated places