### PR TITLE
'invite_hash' parameter is optional

### DIFF
--- a/pytgcalls/methods/groups/join_group_call.py
+++ b/pytgcalls/methods/groups/join_group_call.py
@@ -41,7 +41,7 @@ class JoinGroupCall(Scaffold):
                 :obj:`~pytgcalls.types.AudioImagePiped()`,
                 :obj:`~pytgcalls.types.AudioVideoPiped()` or
                 :obj:`~pytgcalls.types.VideoPiped()`
-            invite_hash (``str``):
+            invite_hash (``str``, **optional**):
                 Unique identifier for the invite in a group call
                 in form of a t.me link
             join_as (`InputPeer (P)`_ | `InputPeer (T)`_, **optional**):


### PR DESCRIPTION
The invite_hash parameter is optional but it's not shown in the docs