### PR TITLE
Update mutex.py

### DIFF
--- a/pytgcalls/mutex.py
+++ b/pytgcalls/mutex.py
@@ -26,6 +26,8 @@ def mutex(func):
                 )
             if chat_id is not None:
                 name = f'{func.__name__}_{chat_id}'
+                if not hasattr(self, '_lock'):
+                    self._lock = {}
                 if name not in self._lock:
                     self._lock[name] = asyncio.Lock()
                 async with self._lock[name]:


### PR DESCRIPTION
- `_lock` attribute is created as an empty dictionary if it does not exist in the instance.

