### PR TITLE
Update mtproto_required.py

### DIFF
--- a/pytgcalls/mtproto_required.py
+++ b/pytgcalls/mtproto_required.py
@@ -1,8 +1,8 @@
 from functools import wraps
 
 from .exceptions import ClientNotStarted
-from .exceptions import NoMTProtoClientSet
 from .exceptions import MTProtoClientNotConnected
+from .exceptions import NoMTProtoClientSet
 
 
 def mtproto_required(func):

--- a/pytgcalls/mtproto_required.py
+++ b/pytgcalls/mtproto_required.py
@@ -2,6 +2,7 @@ from functools import wraps
 
 from .exceptions import ClientNotStarted
 from .exceptions import NoMTProtoClientSet
+from .exceptions import MTProtoClientNotConnected
 
 
 def mtproto_required(func):
@@ -12,6 +13,9 @@ def mtproto_required(func):
 
         if not self._is_running:
             raise ClientNotStarted()
+
+        if not self._app.is_connected:
+            raise MTProtoClientNotConnected()
 
     @wraps(func)
     async def async_wrapper(*args, **kwargs):


### PR DESCRIPTION
- [x] exception `MTProtoClientNotConnected` to handle cases where the MTProto client is not connected.
- [x] In the `check_mtproto `function, I am added a check to ensure that the `_app `object `is_connected `(`self._app.is_connected`). If it's not connected, the `MTProtoClientNotConnected` exception is raised.