### PR TITLE
Fixed NotImplementedError while using uvloop

### DIFF
--- a/pytgcalls/ffmpeg.py
+++ b/pytgcalls/ffmpeg.py
@@ -284,9 +284,11 @@ def _build_ffmpeg_options(
             '-ar', str(stream_parameters.bitrate),
         ])
     elif isinstance(stream_parameters, VideoParameters):
-        options.extend([
+       options.extend([
             'rawvideo',
             '-r', str(stream_parameters.frame_rate),
+            '-pix_fmt',
+            'yuv420p',
             '-vf',
             f'scale={stream_parameters.width}:{stream_parameters.height}',
         ])

--- a/pytgcalls/ffmpeg.py
+++ b/pytgcalls/ffmpeg.py
@@ -146,12 +146,13 @@ async def cleanup_commands(
         result = proc_res.stdout
         supported = re.findall(r'(?m)^ *(-.*?)\s+', result)
 
-        new_commands = [
-            v for v in commands if v and (
-                v[0] != '-' or (v in supported and (not blacklist or v not in blacklist))
-            )
-        ]
-
+        for v in commands:
+            if len(v) > 0:
+                if v[0] == '-':
+                    ignore_next = v not in supported or \
+                        blacklist is not None and v in blacklist
+                if not ignore_next:
+                    new_commands += [v]
         return new_commands
 
     except subprocess.TimeoutExpired:

--- a/pytgcalls/ffmpeg.py
+++ b/pytgcalls/ffmpeg.py
@@ -57,7 +57,9 @@ async def check_stream(
         if proc_res.returncode != 0:
             if 'No such file' in result.stdout.splitlines():
                 raise FileNotFoundError()
-            raise FFmpegError(f"Error in ffprobe execution: {result.stdout.splitlines()}")
+            raise FFmpegError(
+                f"Error in ffprobe execution: {result.stdout.splitlines()}",
+            )
         result = loads(result.stdout.splitlines()) or {}
         stream_list = result.get('streams', [])
         format_content = result.get('format', {})

--- a/pytgcalls/ffmpeg.py
+++ b/pytgcalls/ffmpeg.py
@@ -145,7 +145,17 @@ async def cleanup_commands(
 
         result = proc_res.stdout
         supported = re.findall(r'(?m)^ *(-.*?)\s+', result)
+        new_commands = []
+        ignore_next = False
 
+        for v in commands:
+            if len(v) > 0:
+                if v[0] == '-':
+                    ignore_next = v not in supported or \
+                        blacklist is not None and v in blacklist
+                if not ignore_next:
+                    new_commands += [v]
+        return new_commands
         for v in commands:
             if len(v) > 0:
                 if v[0] == '-':

--- a/pytgcalls/ffmpeg.py
+++ b/pytgcalls/ffmpeg.py
@@ -69,7 +69,12 @@ async def check_stream(
     except JSONDecodeError:
         raise FFmpegError('Failed to parse ffprobe output')
 
-    have_video, is_image, have_audio, have_valid_video = False, False, False, False
+
+    have_video = False
+    is_image = False
+    have_audio = False
+    have_valid_video = False
+
     original_width, original_height = 0, 0
 
     for stream in stream_list:

--- a/pytgcalls/ffmpeg.py
+++ b/pytgcalls/ffmpeg.py
@@ -55,10 +55,10 @@ async def check_stream(
         )
 
         if proc_res.returncode != 0:
-            if 'No such file' in proc_res.stderr:
+            if 'No such file' in result.stdout.splitlines():
                 raise FileNotFoundError()
-            raise FFmpegError(f"Error in ffprobe execution: {proc_res.stderr}")
-        result = loads(proc_res.stdout) or {}
+            raise FFmpegError(f"Error in ffprobe execution: {result.stdout.splitlines()}")
+        result = loads(result.stdout.splitlines()) or {}
         stream_list = result.get('streams', [])
         format_content = result.get('format', {})
 

--- a/pytgcalls/ffmpeg.py
+++ b/pytgcalls/ffmpeg.py
@@ -50,8 +50,8 @@ async def check_stream(
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                timeout=20
-            )
+                timeout=20,
+            ),
         )
 
         if proc_res.returncode != 0:
@@ -63,11 +63,11 @@ async def check_stream(
         format_content = result.get('format', {})
 
     except subprocess.TimeoutExpired:
-        raise FFmpegError("Command timed out")
+        raise FFmpegError('Command timed out')
     except FileNotFoundError:
         raise FFmpegError('ffprobe not installed')
     except JSONDecodeError:
-        raise FFmpegError("Failed to parse ffprobe output")
+        raise FFmpegError('Failed to parse ffprobe output')
 
     have_video, is_image, have_audio, have_valid_video = False, False, False, False
     original_width, original_height = 0, 0
@@ -76,7 +76,7 @@ async def check_stream(
         codec_type = stream.get('codec_type', '')
         codec_name = stream.get('codec_name', '')
         image_codecs = ['png', 'jpeg', 'jpg', 'mjpeg']
-        
+
         if codec_type == 'video':
             is_image = codec_name in image_codecs
             have_video = True
@@ -91,7 +91,7 @@ async def check_stream(
         if not have_video:
             raise NoVideoSourceFound(path)
         if not have_valid_video:
-            raise InvalidVideoProportion("Video proportion not found")
+            raise InvalidVideoProportion('Video proportion not found')
 
         ratio = float(original_width) / original_height
         new_w = min(original_width, stream_parameters.width)
@@ -117,7 +117,6 @@ async def check_stream(
         raise LiveStreamFound(path)
 
 
-
 async def cleanup_commands(
     commands: List[str],
     process_name: Optional[str] = None,
@@ -133,8 +132,8 @@ async def cleanup_commands(
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                timeout=20
-            )
+                timeout=20,
+            ),
         )
 
         if proc_res.returncode != 0:
@@ -148,13 +147,14 @@ async def cleanup_commands(
                 v[0] != '-' or (v in supported and (not blacklist or v not in blacklist))
             )
         ]
-        
+
         return new_commands
 
     except subprocess.TimeoutExpired:
-        raise FFmpegError("Command timed out")
+        raise FFmpegError('Command timed out')
     except FileNotFoundError:
         raise FFmpegError(f'{commands[0]} not installed')
+
 
 def build_command(
     name: str,
@@ -292,4 +292,3 @@ def _build_ffmpeg_options(
         ])
 
     return options
-    

--- a/pytgcalls/ffmpeg.py
+++ b/pytgcalls/ffmpeg.py
@@ -284,7 +284,7 @@ def _build_ffmpeg_options(
             '-ar', str(stream_parameters.bitrate),
         ])
     elif isinstance(stream_parameters, VideoParameters):
-       options.extend([
+        options.extend([
             'rawvideo',
             '-r', str(stream_parameters.frame_rate),
             '-pix_fmt',

--- a/pytgcalls/ffmpeg.py
+++ b/pytgcalls/ffmpeg.py
@@ -69,7 +69,6 @@ async def check_stream(
     except JSONDecodeError:
         raise FFmpegError('Failed to parse ffprobe output')
 
-
     have_video = False
     is_image = False
     have_audio = False

--- a/pytgcalls/media_devices/media_devices.py
+++ b/pytgcalls/media_devices/media_devices.py
@@ -54,16 +54,19 @@ class MediaDevices:
                     'list',
                     'sources',
                 ]
-            ffmpeg = await asyncio.create_subprocess_exec(
-                *tuple(commands),
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
             try:
-                stdout, stderr = await asyncio.wait_for(
-                    ffmpeg.communicate(),
-                    timeout=3,
+                loop = asyncio.get_event_loop()
+                result = await loop.run_in_executor(
+                    None,
+                    lambda: subprocess.run(
+                          commands,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+                          text=True,
+                          timeout=3
+                    )
                 )
+                stdout, stderr = result
                 result: str = ''
                 if platform == 'win32':
                     result = stderr.decode('utf-8')

--- a/pytgcalls/media_devices/media_devices.py
+++ b/pytgcalls/media_devices/media_devices.py
@@ -59,12 +59,12 @@ class MediaDevices:
                 result = await loop.run_in_executor(
                     None,
                     lambda: subprocess.run(
-                          commands,
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE,
-                          text=True,
-                          timeout=3
-                    )
+                        commands,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                        timeout=3,
+                    ),
                 )
                 stdout, stderr = result
                 result: str = ''

--- a/pytgcalls/ytdlp.py
+++ b/pytgcalls/ytdlp.py
@@ -1,6 +1,6 @@
 import asyncio
-import re
 import logging
+import re
 import shlex
 import subprocess
 from typing import Optional
@@ -59,7 +59,7 @@ class YtDlp:
         py_logger.log(
             logging.DEBUG,
             f'Running with "{" ".join(commands)}" command',
-         )
+        )
         loop = asyncio.get_running_loop()
         try:
             proc_res = await loop.run_in_executor(

--- a/pytgcalls/ytdlp.py
+++ b/pytgcalls/ytdlp.py
@@ -57,7 +57,7 @@ class YtDlp:
             )
 
         commands.append(link)
- 
+
         py_logger.log(
             logging.DEBUG,
             f'Running with "{" ".join(commands)}" command',

--- a/pytgcalls/ytdlp.py
+++ b/pytgcalls/ytdlp.py
@@ -10,6 +10,9 @@ from .ffmpeg import cleanup_commands
 from .types.raw import VideoParameters
 
 
+py_logger = logging.getLogger('pytgcalls')
+
+
 class YtDlp:
     YOUTUBE_REGX = re.compile(
         r'^((?:https?:)?//)?((?:www|m)\.)?'

--- a/pytgcalls/ytdlp.py
+++ b/pytgcalls/ytdlp.py
@@ -9,16 +9,6 @@ from .ffmpeg import cleanup_commands
 from .types.raw import VideoParameters
 
 
-import asyncio
-import re
-import shlex
-from typing import Optional, Tuple
-
-from .exceptions import YtDlpError
-from .ffmpeg import cleanup_commands
-from .types.raw import VideoParameters
-
-
 class YtDlp:
     YOUTUBE_REGX = re.compile(
         r'^((?:https?:)?//)?((?:www|m)\.)?'
@@ -71,8 +61,8 @@ class YtDlp:
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
-                    timeout=20
-                )
+                    timeout=20,
+                ),
             )
             if proc_res.returncode != 0:
                 raise YtDlpError(proc_res.stderr)

--- a/pytgcalls/ytdlp.py
+++ b/pytgcalls/ytdlp.py
@@ -57,6 +57,7 @@ class YtDlp:
             )
 
         commands.append(link)
+ 
         py_logger.log(
             logging.DEBUG,
             f'Running with "{" ".join(commands)}" command',

--- a/pytgcalls/ytdlp.py
+++ b/pytgcalls/ytdlp.py
@@ -1,6 +1,7 @@
 import asyncio
 import re
 import shlex
+import subprocess
 from typing import Optional
 from typing import Tuple
 

--- a/pytgcalls/ytdlp.py
+++ b/pytgcalls/ytdlp.py
@@ -1,6 +1,6 @@
 import asyncio
-import re
 import logging
+import re
 import shlex
 import subprocess
 from typing import Optional

--- a/pytgcalls/ytdlp.py
+++ b/pytgcalls/ytdlp.py
@@ -10,7 +10,6 @@ from .exceptions import YtDlpError
 from .ffmpeg import cleanup_commands
 from .types.raw import VideoParameters
 
-
 py_logger = logging.getLogger('pytgcalls')
 
 

--- a/pytgcalls/ytdlp.py
+++ b/pytgcalls/ytdlp.py
@@ -1,6 +1,6 @@
 import asyncio
-import logging
 import re
+import logging
 import shlex
 import subprocess
 from typing import Optional
@@ -56,7 +56,10 @@ class YtDlp:
             )
 
         commands.append(link)
-
+        py_logger.log(
+            logging.DEBUG,
+            f'Running with "{" ".join(commands)}" command',
+         )
         loop = asyncio.get_running_loop()
         try:
             proc_res = await loop.run_in_executor(

--- a/pytgcalls/ytdlp.py
+++ b/pytgcalls/ytdlp.py
@@ -38,8 +38,10 @@ class YtDlp:
             'yt-dlp',
             '-g',
             '-f',
-            f'best[width<=?{video_parameters.width}]'
-            f'[height<=?{video_parameters.height}]',
+            'bestvideo[vcodec~=\'(vp09|avc1)\']+m4a/best',
+            '-S',
+            'res:'
+            f'{min(video_parameters.width, video_parameters.height)}',
             '--no-warnings',
         ]
 

--- a/pytgcalls/ytdlp.py
+++ b/pytgcalls/ytdlp.py
@@ -1,8 +1,8 @@
-import subprocess
 import asyncio
 import logging
 import re
 import shlex
+import subprocess
 from typing import Optional
 from typing import Tuple
 

--- a/pytgcalls/ytdlp.py
+++ b/pytgcalls/ytdlp.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+import logging
 import shlex
 import subprocess
 from typing import Optional

--- a/pytgcalls/ytdlp.py
+++ b/pytgcalls/ytdlp.py
@@ -1,8 +1,8 @@
+import subprocess
 import asyncio
 import logging
 import re
 import shlex
-import subprocess
 from typing import Optional
 from typing import Tuple
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/root/shv2/ShraddhaMusic/plugins/playcmd.py", line 139, in play_commnd
    await stream(_,mystic,user_id,details,chat_id,user_name,message.chat.id,video=video,streamtype=streamtype,forceplay=fplay)
  File "/root/shv2/ShraddhaMusic/utils/player.py", line 104, in stream
    await Shraddha.join_call(chat_id,original_chat_id,file_path,video=video)
  File "/root/shv2/ShraddhaMusic/call.py", line 237, in join_call
    await assistant.play(chat_id,stream)
  File "/root/myvenv/lib/python3.12/site-packages/pytgcalls/mutex.py", line 9, in async_wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/myvenv/lib/python3.12/site-packages/pytgcalls/statictypes.py", line 96, in async_wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/myvenv/lib/python3.12/site-packages/pytgcalls/mtproto_required.py", line 23, in async_wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/myvenv/lib/python3.12/site-packages/pytgcalls/methods/stream/play.py", line 47, in play
    media_description = await StreamParams.get_stream_params(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/myvenv/lib/python3.12/site-packages/pytgcalls/methods/utilities/stream_params.py", line 19, in get_stream_params
    await stream.check_stream()
  File "/root/myvenv/lib/python3.12/site-packages/pytgcalls/types/stream/media_stream.py", line 193, in check_stream
    await check_stream(
  File "/root/myvenv/lib/python3.12/site-packages/pytgcalls/ffmpeg.py", line 33, in check_stream
    ffprobe = await asyncio.create_subprocess_exec(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/subprocess.py", line 224, in create_subprocess_exec
    transport, protocol = await loop.subprocess_exec(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 1744, in subprocess_exec
    transport = await self._make_subprocess_transport(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/unix_events.py", line 200, in _make_subprocess_transport
    watcher = events.get_child_watcher()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/events.py", line 828, in get_child_watcher
    return get_event_loop_policy().get_child_watcher()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/events.py", line 645, in get_child_watcher
    raise NotImplementedE