### PR TITLE
Skip evicted entries in get_chat_id instead of crashing

### DIFF
--- a/pytgcalls/mtproto/client_cache.py
+++ b/pytgcalls/mtproto/client_cache.py
@@ -109,6 +109,8 @@ class ClientCache:
     ) -> Optional[int]:
         for key in self._input_calls.keys:
             call = self._input_calls.get(key)
+            if call is None:
+                continue
             if call_id == (call.slug if hasattr(call, 'slug') else call.id):
                 self._input_calls.update_cache(key)
                 return key


### PR DESCRIPTION
Fixes #330. get_chat_id iterates `_input_calls.keys` and calls `.get(key)` for each one, but an entry can already be gone by the time `.get()` runs (it may have expired or been dropped), so `call` ends up None and the following `call.slug`/`call.id` access raises AttributeError. This just skips entries that resolved to None instead of touching them.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pytgcalls/codesmith/pytgcalls/pr/331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788040688&installation_model_id=422679&pr_number=331&repository=pytgcalls%2Fpytgcalls&return_to=https%3A%2F%2Fgithub.com%2Fpytgcalls%2Fpytgcalls%2Fpull%2F331&signature=cd92f3946da7da66cebdce7459b9f8e0041261daca75c508667cce7291c56ad7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->