### PR TITLE
Do not drive signalling callbacks through async_to_sync

### DIFF
--- a/pytgcalls/methods/internal/__init__.py
+++ b/pytgcalls/methods/internal/__init__.py
@@ -1,6 +1,8 @@
 from .clear_cache import ClearCache
 from .clear_call import ClearCall
 from .connect_call import ConnectCall
+from .emit_outbound_block import EmitOutboundBlock
+from .emit_signaling_data import EmitSignalingData
 from .handle_connection_changed import HandleConnectionChanged
 from .handle_emojis_update import HandleEmojisUpdate
 from .handle_mtproto_updates import HandleMTProtoUpdates
@@ -21,6 +23,8 @@ class Internal(
     ClearCache,
     ClearCall,
     ConnectCall,
+    EmitOutboundBlock,
+    EmitSignalingData,
     HandleConnectionChanged,
     HandleEmojisUpdate,
     HandleMTProtoUpdates,

--- a/pytgcalls/methods/internal/emit_outbound_block.py
+++ b/pytgcalls/methods/internal/emit_outbound_block.py
@@ -1,0 +1,9 @@
+from ...scaffold import Scaffold
+
+
+class EmitOutboundBlock(Scaffold):
+    async def _emit_outbound_block(self, chat_id: int, block: bytes):
+        await self._app.send_conference_call_broadcast(
+            chat_id,
+            block,
+        )

--- a/pytgcalls/methods/internal/emit_signaling_data.py
+++ b/pytgcalls/methods/internal/emit_signaling_data.py
@@ -1,0 +1,9 @@
+from ...scaffold import Scaffold
+
+
+class EmitSignalingData(Scaffold):
+    async def _emit_signaling_data(self, chat_id: int, data: bytes):
+        await self._app.send_signaling(
+            chat_id,
+            data,
+        )

--- a/pytgcalls/methods/utilities/start.py
+++ b/pytgcalls/methods/utilities/start.py
@@ -59,7 +59,7 @@ class Start(Scaffold):
             )
             self._binding.on_signaling_data(
                 lambda chat_id, data: asyncio.run_coroutine_threadsafe(
-                    self._app.send_signaling(chat_id, data),
+                    self._emit_signaling_data(chat_id, data),
                     self.loop,
                 ),
             )
@@ -95,10 +95,7 @@ class Start(Scaffold):
             self._binding.on_outbound_block(
                 lambda chat_id, block:
                 asyncio.run_coroutine_threadsafe(
-                    self._app.send_conference_call_broadcast(
-                        chat_id,
-                        block,
-                    ),
+                    self._emit_outbound_block(chat_id, block),
                     self.loop,
                 ),
             )


### PR DESCRIPTION
## The bug

On the `dev` line a 1:1 call never establishes media. Signalling completes, the DH exchange completes, Telegram supplies valid relays, and then `ConnectionState` goes `CONNECTING` → `TIMEOUT` exactly ten seconds later. Reported as pytgcalls/ntgcalls#58, where it looked like a transport defect.

It is not. Every outbound ICE candidate is dropped before it leaves the process.

`sync.wrap(MtProtoClient)` replaces every public async method of that class with `async_to_sync_wrap`. So in `start()`:

```python
self._binding.on_signaling_data(
    lambda chat_id, data: asyncio.run_coroutine_threadsafe(
        self._app.send_signaling(chat_id, data),   # not a coroutine — a call
        self.loop,
    ),
)
```

the argument is not a coroutine object. It is the wrapper running the request. Inside the wrapper, `main_loop` is captured when `pytgcalls.sync` is imported — before the application's loop exists — so `main_loop.is_running()` is false for the lifetime of the process. Called from ntgcalls' worker thread the wrapper takes the synchronous branch, creates a fresh event loop in that thread, and drives the MTProto request on it:

```
File ".../pytgcalls/sync.py", line 59, in async_to_sync_wrap
    return loop.run_until_complete(coroutine)
File ".../pytgcalls/mtproto/mtproto_client.py", line 225, in send_signaling
    await self._bind_client.send_signaling(
File ".../pytgcalls/mtproto/telethon_client.py", line 782, in send_signaling
    await self._invoke(
File ".../pytgcalls/mtproto/telethon_client.py", line 1022, in _invoke
    return await self._app._call(
File ".../telethon/client/users.py", line 34, in _call
    raise RuntimeError('The asyncio event loop must not change after connection (see the FAQ for details)')
```

The peer's candidates still arrive and pairs are still formed, so ICE looks healthy from this side — but the peer never learns our candidates, no pair becomes writable, and the call times out.

The reason this went unnoticed for so long is that the exception is caught by ntgcalls' `synchronized_callback` and logged through `LogSink`, which sets its own loggers to `CRITICAL` when it finds them at `NOTSET`. Nothing surfaces unless the application claims `logging.getLogger('ntgcalls')` first.

## The fix

Route both affected callbacks through internal coroutine methods, exactly as every other callback in `start()` already does — `_handle_stream_ended`, `_update_status`, `_handle_connection_changed` and the rest all work for this reason. `sync.wrap()` skips names beginning with an underscore, so a real coroutine reaches `run_coroutine_threadsafe` and runs on the client's own loop.

`on_outbound_block` had the same defect, calling `self._app.send_conference_call_broadcast(...)` directly, and is fixed the same way.

For what it is worth, the `master` line does not have this bug: its signalling callback calls `self._emit_sig_data(...)`, which is the shape restored here.

## Measurements

One build, `ntgcalls 3.0.0b16`, one account, one machine, one network, an iPhone on Telegram for iOS 12.9.2 as the other party, runs minutes apart:

| signalling callback | candidates delivered | exceptions | result |
|---|---|---|---|
| `dev` as it stands | 0 of 19 | 19 | `ConnectionState.TIMEOUT` after 10.0s |
| routed through a coroutine method | 19 of 19 | 0 | **`ConnectionState.CONNECTED`** |

Control on `py-tgcalls 2.3.3` / `ntgcalls 2.2.5`, same account and network: `CONNECTED` within the same second.

Direction makes no difference — answering and placing both failed before the change, on different relay sets (incoming was offered a WebRTC TURN/STUN server plus a legacy reflector with `p2p_allowed=True`; outgoing only the reflector with `p2p_allowed=False`), and both failed at the same ten-second mark.

## Checks

flake8 clean on the touched files. After the change:

```
Internal MRO composes: True
_emit_signaling_data is a coroutine function: True
_emit_outbound_block is a coroutine function: True
send_signaling on MtProtoClient is sync-wrapped: True
```

The last line is the defect itself, left in as the thing the fix routes around.

## A suggestion, not part of this change

`run_coroutine_threadsafe` returns a future nobody retrieves, so a failure in any of these callbacks is silent even when the loop is correct. Logging the future's exception would have turned this into a one-line diagnosis rather than a three-week hunt.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pytgcalls/codesmith/pytgcalls/pr/334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789744098&installation_model_id=422679&pr_number=334&repository=pytgcalls%2Fpytgcalls&return_to=https%3A%2F%2Fgithub.com%2Fpytgcalls%2Fpytgcalls%2Fpull%2F334&signature=ec3aac8864f30e0fe7736acee7391e35a3ff9b512c00eee854605bc3117751e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->