### PR TITLE
Default Frame.Info.rotation to the rotation type it is passed as

### DIFF
--- a/pytgcalls/types/stream/frame.py
+++ b/pytgcalls/types/stream/frame.py
@@ -1,3 +1,5 @@
+from ntgcalls import VideoRotation
+
 from ...types.update import PyObject
 
 
@@ -8,7 +10,7 @@ class Frame(PyObject):
             capture_time: int = 0,
             width: int = 0,
             height: int = 0,
-            rotation: int = 0,
+            rotation: VideoRotation = VideoRotation.VIDEO_ROTATION_0,
         ):
             self.capture_time = capture_time
             self.width = width


### PR DESCRIPTION
`send_frame` cannot be called successfully on this line without naming a video rotation, which audio callers have no reason to do.

`send_frame` passes `frame_data.rotation` straight into `ntgcalls.FrameData`, and that constructor takes a `VideoRotation`:

```python
FrameData(
    frame_data.capture_time,
    frame_data.rotation,
    frame_data.width,
    frame_data.height,
)
```

`Frame.Info` defaults that field to the int `0`, so the default path raises:

```
TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. ntgcalls.FrameData()
    2. ntgcalls.FrameData(absolute_capture_timestamp_ms: ..., rotation: ntgcalls.VideoRotation, width: ..., height: ...)

Invoked with: 1755624000000, 0, 0, 0
```

We hit this driving a live voice agent into a call: every outbound audio frame raised, the send pump stopped on the first one, and the call stayed silent in that direction while looking healthy everywhere else.

The receive path already carries the enum — `_handle_stream_frame` builds `Frame.Info` from `x.frame_data.rotation` — so the default was the only place the field held an int. This changes the default to `VideoRotation.VIDEO_ROTATION_0` and annotates the parameter with the type it actually holds.

After the change, what `send_frame` does internally accepts the default:

```
default rotation: <VideoRotation.VIDEO_ROTATION_0: 0>
FrameData accepts the default: OK
```

Callers that already pass a `VideoRotation` are unaffected; callers that passed the int `0` were raising before, so nothing that worked stops working.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pytgcalls/codesmith/pytgcalls/pr/335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789752685&installation_model_id=422679&pr_number=335&repository=pytgcalls%2Fpytgcalls&return_to=https%3A%2F%2Fgithub.com%2Fpytgcalls%2Fpytgcalls%2Fpull%2F335&signature=74a8fd9096ff667b73a906feab1813e6b3d86a9b2cb96dfb512824df19a57677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->