### PR TITLE
Remap conference audio when the roster moves

### DIFF
--- a/pytgcalls/methods/internal/handle_mtproto_updates.py
+++ b/pytgcalls/methods/internal/handle_mtproto_updates.py
@@ -159,6 +159,16 @@ class HandleMTProtoUpdates(Scaffold):
                                 user_id, None,
                             )
 
+                    # Audio is mapped once, when the media layer asks who is
+                    # in the call. Nothing has remapped it since, so a
+                    # participant who was not in that first answer is never
+                    # decoded. The cache this reads was just updated from this
+                    # very update, so no request leaves the process.
+                    try:
+                        await self._handle_request_participants(chat_id)
+                    except (ConnectionNotFound, ConnectionError):
+                        pass
+
             if chat_peer:
                 is_self = BridgedClient.chat_id(
                     chat_peer,


### PR DESCRIPTION
Participants who were not in the call's first participant answer are never decoded, for the whole call.

`_handle_request_participants` builds the audio SSRC map when the media layer asks who is in the call, and nothing calls it again. The participant-update handler that runs on every roster change refreshes `camera` and `presentation` sources only — audio is never remapped. The participant list behind it is cached for an hour, so nothing corrects it later either.

Anyone still being admitted when the join completes, or who joins afterwards, is silent from our side for the rest of the call.

## How it showed up

Recording an E2EE conference. The account that created the conference and invited us was missing from the capture entirely; the third party came through normally. Nothing in the call looked wrong — the join succeeded, frames arrived, the recording was the right length.

Measured on the same conference, before and after remapping on roster changes:

| | bitrate | mean volume |
|---|---|---|
| as it stands | 45 kb/s | −30.3 dB |
| remapped | 88 kb/s | −23.1 dB |

Same codec, same settings, same call — the difference is a second stream being decoded.

## The change

Call `_handle_request_participants(chat_id)` from the participant-update handler, inside the same `chat_id in self._call_sources` branch that already maintains video sources, guarded the same way its neighbours are.

It costs no request: the cache it reads was updated from the same update that reached the handler, so `get_participant_list` answers from memory.

I am not attached to this shape — if the map belongs somewhere else, or should be diffed rather than rebuilt, say so and I will redo it. What matters is that something remaps audio when the roster moves.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pytgcalls/codesmith/pytgcalls/pr/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789752772&installation_model_id=422679&pr_number=336&repository=pytgcalls%2Fpytgcalls&return_to=https%3A%2F%2Fgithub.com%2Fpytgcalls%2Fpytgcalls%2Fpull%2F336&signature=da889512f86e579b5c7546b00b8539984290f97c7a33cd12c938aba68eb91782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->